### PR TITLE
Added IWebSocketConnection interface

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: npm install && npm run compile

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,9 +102,9 @@
       }
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "^7.0.56",
     "rimraf": "^2.6.2",
-    "typescript": "^2.7.2"
+    "typescript": "3.5.3"
   },
   "dependencies": {
     "vscode-jsonrpc": "^4.1.0-next"

--- a/src/server/connection.ts
+++ b/src/server/connection.ts
@@ -19,7 +19,8 @@ export interface IConnection extends Disposable {
     onClose(callback: () => void): Disposable;
 }
 
-export function createConnection(reader: MessageReader, writer: MessageWriter, onDispose: () => void): IConnection {
+export function createConnection<T extends {}>(reader: MessageReader, writer: MessageWriter, onDispose: () => void,
+        extensions: T = {} as T): IConnection & T {
     const disposeOnClose = new DisposableCollection();
     reader.onClose(() => disposeOnClose.dispose());
     writer.onClose(() => disposeOnClose.dispose());
@@ -34,6 +35,7 @@ export function createConnection(reader: MessageReader, writer: MessageWriter, o
         onClose(callback: () => void): Disposable {
             return disposeOnClose.push(Disposable.create(callback));
         },
-        dispose: () => onDispose()
-    }
+        dispose: () => onDispose(),
+        ...extensions
+    };
 }

--- a/src/server/launch.ts
+++ b/src/server/launch.ts
@@ -8,7 +8,7 @@ import * as stream from 'stream';
 import * as cp from 'child_process';
 import { StreamMessageReader, StreamMessageWriter, SocketMessageReader, SocketMessageWriter } from "vscode-jsonrpc";
 import { IConnection, createConnection } from "./connection";
-import { IWebSocket, WebSocketMessageReader, WebSocketMessageWriter } from '../socket';
+import { IWebSocket, WebSocketMessageReader, WebSocketMessageWriter, IWebSocketConnection } from '../socket';
 
 export function createServerProcess(serverName: string, command: string, args?: string[], options?: cp.SpawnOptions): IConnection {
     const serverProcess = cp.spawn(command, args, options);
@@ -21,10 +21,10 @@ export function createServerProcess(serverName: string, command: string, args?: 
     return createProcessStreamConnection(serverProcess);
 }
 
-export function createWebSocketConnection(socket: IWebSocket): IConnection {
+export function createWebSocketConnection(socket: IWebSocket): IWebSocketConnection {
     const reader = new WebSocketMessageReader(socket);
     const writer = new WebSocketMessageWriter(socket);
-    return createConnection(reader, writer, () => socket.dispose());
+    return createConnection(reader, writer, () => socket.dispose(), { socket });
 }
 
 export function createProcessSocketConnection(process: cp.ChildProcess, outSocket: net.Socket, inSocket: net.Socket = outSocket): IConnection {

--- a/src/socket/socket.ts
+++ b/src/socket/socket.ts
@@ -3,10 +3,15 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { Disposable } from "../disposable";
+import { IConnection } from "../server/connection";
 
 export interface IWebSocket extends Disposable {
     send(content: string): void;
     onMessage(cb: (data: any) => void): void;
     onError(cb: (reason: any) => void): void;
     onClose(cb: (code: number, reason: string) => void): void;
+}
+
+export interface IWebSocketConnection extends IConnection {
+    readonly socket: IWebSocket;
 }


### PR DESCRIPTION
In eclipse-theia/theia#6854 I introduced an extension of the IConnection interface and a `create` function to add a property to an existing IConnection. It would be better to include support for such an extension directly in the library.

This change adds generic extension support to `createConnection` and uses that in `createWebSocketConnection` to include the IWebSocket in the created connection.