### PR TITLE
Bump node, vscode-jsonrpc and typescript versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,15 +102,15 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "vscode-jsonrpc": {
-      "version": "4.1.0-next.2",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.2.tgz",
-      "integrity": "sha512-GsBLjP9DxQ42yl1mW9GEIlnSc0+R8mfzhaebwmmTPEJjezD5SPoAo3DFrIAFZha9yvQ1nzZfZlhtVpGQmgxtXg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
+      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "7.0.56",
-      "resolved": "http://registry.npmjs.org/@types/node/-/node-7.0.56.tgz",
-      "integrity": "sha512-NgjN3xPyqbAXSIpznNAR5Cisx5uKqJWxcS9kefzSFEX/9J7O01/FHyfnvPI7SztBf9p6c8mqOn3olZWJx3ja6g==",
+      "version": "10.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+      "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
       "dev": true
     },
     "balanced-match": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index",
   "devDependencies": {
-    "@types/node": "^7.0.56",
+    "@types/node": "10.17.14",
     "rimraf": "^2.6.2",
     "typescript": "3.7.5"
   },

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "@types/node": "^7.0.56",
     "rimraf": "^2.6.2",
-    "typescript": "3.5.3"
+    "typescript": "3.7.5"
   },
   "dependencies": {
-    "vscode-jsonrpc": "^4.1.0-next"
+    "vscode-jsonrpc": "^5.0.0"
   },
   "scripts": {
     "prepublish": "npm run compile",


### PR DESCRIPTION
Closes https://github.com/TypeFox/vscode-ws-jsonrpc/issues/17

We need it to bump the new Monaco version, please see more details [here](https://github.com/TypeFox/monaco-languageclient/pull/199#issuecomment-578815691)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>