### PR TITLE
Add ability to handle ready websocket connections

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -13,11 +13,19 @@ export function listen(options: {
 }) {
     const { webSocket, onConnection } = options;
     const logger = options.logger || new ConsoleLogger();
-    webSocket.onopen = () => {
-        const socket = toSocket(webSocket);
+    
+    const socket = toSocket(webSocket);
+    
+
+    if (webSocket.readyState === WebSocket.OPEN) {
         const connection = createWebSocketConnection(socket, logger);
-        onConnection(connection);
-    };
+        onConnection(connection);  
+    } else {
+        webSocket.onopen = () => {
+            const connection = createWebSocketConnection(socket, logger);
+            onConnection(connection);  
+        };
+    }
 }
 
 export function toSocket(webSocket: WebSocket): IWebSocket {


### PR DESCRIPTION
Currently, if a websocket connection is lazily passed, whose `onopen` is already fired, the module never initializes hence does not work. This fixes it by checking the `readyState` of socket. If it is ready it initializes it right away, otherwise adds the `onopen` handle, as earlier